### PR TITLE
smallhours onboarding

### DIFF
--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -1,0 +1,42 @@
+# smallhours consumer stub — copy this into a consumer repo as
+# .github/workflows/agent-loop.yml. It is DELIBERATELY thin: triggers, a
+# permissions ceiling, and one versioned `uses:` line. All behaviour lives
+# behind the `@v1` tag in the toolkit repo, so this file rarely needs syncing
+# (drift is caught by setup/doctor.sh).
+#
+# Secret forwarding matches the three secrets agent-loop.yml declares as
+# required. setup-repo.sh creates those secrets + installs the Fixer App.
+#
+# Comments are kept on their own lines and scalars plain/single-quoted, so this
+# file passes strict consumer YAML linters (eslint-plugin-yml, yamllint) as-is.
+name: agent-loop
+
+# All five triggers the routing table keys off.
+on:
+  issues:
+    types: [labeled, unlabeled, closed]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    # Must match the ci_workflow name in .smallhours.yml.
+    workflows: [CI]
+    types: [completed]
+  schedule:
+    # Phase 1: no-op. Phase 2: sweep cadence. The stub never changes.
+    - cron: '*/15 * * * *'
+
+# Consumer-side ceiling. The reusable workflow cannot exceed this; it requests
+# less per job.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  loop:
+    uses: bcanfield/smallhours/.github/workflows/agent-loop.yml@v1
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
+      AGENT_APP_PRIVATE_KEY: ${{ secrets.AGENT_APP_PRIVATE_KEY }}

--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -1,0 +1,38 @@
+# smallhours consumer config. Every key is OPTIONAL — delete any line to take
+# the default shown. setup-repo.sh drops this into a new consumer repo alongside
+# the stub workflow. Defaults live in scripts/lib/config.sh.
+#
+# Comments stay on their own lines so this passes strict YAML linters as-is.
+version: 1
+
+# Per-stage Claude model. Default: claude-sonnet-5 for every stage.
+# auto_fix and resolve_conflict are Phase 2.
+models:
+  implement: claude-sonnet-5
+  address_review: claude-sonnet-5
+  auto_fix: claude-sonnet-5
+  resolve_conflict: claude-sonnet-5
+
+# Per-stage --max-turns ceiling.
+# auto_fix and resolve_conflict are Phase 2.
+max_turns:
+  implement: 50
+  address_review: 30
+  auto_fix: 25
+  resolve_conflict: 20
+
+# Consecutive CI-fix attempts before giving up (Phase 2). Default: 3.
+attempt_cap: 3
+
+# Name of the consumer CI workflow the state machine gates on. Must match the
+# workflows entry in the stub's workflow_run trigger. Default: ci.
+ci_workflow: CI
+
+# Extra domains appended to the sandbox egress allowlist (GitHub + Anthropic are
+# always allowed). Default: none.
+egress_extra_domains: []
+
+# When true, the sandbox reaches registry.npmjs.org AND install lifecycle
+# scripts are disabled (NPM_CONFIG_IGNORE_SCRIPTS=true). When false (default),
+# npm has no network egress.
+npm_allowed: false


### PR DESCRIPTION
Adds the smallhours consumer stub (`.github/workflows/agent-loop.yml`) + `.smallhours.yml`, wired to the `CI` workflow. Merge to activate the loop.