### PR TITLE
smallhours onboarding

### DIFF
--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -1,0 +1,42 @@
+# smallhours consumer stub — copy this into a consumer repo as
+# .github/workflows/agent-loop.yml. It is DELIBERATELY thin: triggers, a
+# permissions ceiling, and one versioned `uses:` line. All behaviour lives
+# behind the `@v1` tag in the toolkit repo, so this file rarely needs syncing
+# (drift is caught by setup/doctor.sh).
+#
+# Secret forwarding matches the three secrets agent-loop.yml declares as
+# required. setup-repo.sh creates those secrets + installs the Fixer App.
+#
+# Comments are kept on their own lines and scalars plain/single-quoted, so this
+# file passes strict consumer YAML linters (eslint-plugin-yml, yamllint) as-is.
+name: agent-loop
+
+# All five triggers the routing table keys off.
+on:
+  issues:
+    types: [labeled, unlabeled, closed]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    # Must match the ci_workflow name in .smallhours.yml.
+    workflows: [CI]
+    types: [completed]
+  schedule:
+    # Phase 1: no-op. Phase 2: sweep cadence. The stub never changes.
+    - cron: '*/15 * * * *'
+
+# Consumer-side ceiling. The reusable workflow cannot exceed this; it requests
+# less per job.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  loop:
+    uses: bcanfield/smallhours/.github/workflows/agent-loop.yml@v1
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
+      AGENT_APP_PRIVATE_KEY: ${{ secrets.AGENT_APP_PRIVATE_KEY }}

--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -1,0 +1,38 @@
+# smallhours consumer config. Every key is OPTIONAL — delete any line to take
+# the default shown. setup-repo.sh drops this into a new consumer repo alongside
+# the stub workflow. Defaults live in scripts/lib/config.sh.
+#
+# Comments stay on their own lines so this passes strict YAML linters as-is.
+version: 1
+
+# Per-stage Claude model. Default: claude-sonnet-5 for every stage.
+# auto_fix and resolve_conflict are Phase 2.
+models:
+  implement: claude-sonnet-5
+  address_review: claude-sonnet-5
+  auto_fix: claude-sonnet-5
+  resolve_conflict: claude-sonnet-5
+
+# Per-stage --max-turns ceiling.
+# auto_fix and resolve_conflict are Phase 2.
+max_turns:
+  implement: 50
+  address_review: 30
+  auto_fix: 25
+  resolve_conflict: 20
+
+# Consecutive CI-fix attempts before giving up (Phase 2). Default: 3.
+attempt_cap: 3
+
+# Name of the consumer CI workflow the state machine gates on. Must match the
+# workflows entry in the stub's workflow_run trigger. Default: ci.
+ci_workflow: CI
+
+# Extra domains appended to the sandbox egress allowlist (GitHub + Anthropic are
+# always allowed). Default: none.
+egress_extra_domains: []
+
+# When true, the sandbox reaches registry.npmjs.org AND install lifecycle
+# scripts are disabled (NPM_CONFIG_IGNORE_SCRIPTS=true). When false (default),
+# npm has no network egress.
+npm_allowed: false

--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -24,9 +24,26 @@ max_turns:
 # Consecutive CI-fix attempts before giving up (Phase 2). Default: 3.
 attempt_cap: 3
 
+# Max issues worked at once. ready-for-agent is an unbounded queue; the
+# dispatcher keeps at most this many in agent-working, promoting the rest as
+# slots free. Default: 3.
+max_concurrent: 3
+
 # Name of the consumer CI workflow the state machine gates on. Must match the
 # workflows entry in the stub's workflow_run trigger. Default: ci.
 ci_workflow: CI
+
+# Map canonical label names (CONTEXT.md vocabulary) to this repo's own label
+# strings, for repos with a pre-existing label scheme. Keys are canonical
+# names; values are what actually appears on issues/PRs. Unmapped names use
+# the canonical string. The workflow-trigger labels — ready-for-agent,
+# agent-working, and the PR marker agent — are FIXED in v1 and cannot be
+# remapped (the reusable workflow gates on them before config is readable).
+# Example:
+#   labels:
+#     in-review: "status: in review"
+#     ready-for-human: "status: needs human"
+labels: {}
 
 # Extra domains appended to the sandbox egress allowlist (GitHub + Anthropic are
 # always allowed). Default: none.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,9 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## System-owned states
+
+`agent-working` and `in-review` are applied and removed by the smallhours loop only.
+Never hand-apply them during triage: removing or adding one by hand is
+a signal to the system (cancellation / state drift), not bookkeeping.


### PR DESCRIPTION
Adds the smallhours consumer stub (`.github/workflows/agent-loop.yml`) + `.smallhours.yml`, wired to the `CI` workflow. Merge to activate the loop.