### PR TITLE
smallhours onboarding

### DIFF
--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -11,19 +11,25 @@
 # file passes strict consumer YAML linters (eslint-plugin-yml, yamllint) as-is.
 name: agent-loop
 
-# All five triggers the routing table keys off.
+# All the trigger surfaces the routing table keys off.
 on:
   issues:
     types: [labeled, unlabeled, closed]
+  pull_request:
+    # T9: an agent PR closed without merging hands the issue back.
+    types: [closed]
   pull_request_review:
-    types: [submitted]
+    # dismissed feeds the green-PR re-evaluation, not a re-summon.
+    types: [submitted, dismissed]
   workflow_run:
     # Must match the ci_workflow name in .smallhours.yml.
     workflows: [CI]
     types: [completed]
   schedule:
-    # Phase 1: no-op. Phase 2: sweep cadence. The stub never changes.
+    # Dispatcher + sweep cadence.
     - cron: '*/15 * * * *'
+  # Manual tick: runs the same dispatcher + sweep pass as the cron.
+  workflow_dispatch:
 
 # Consumer-side ceiling. The reusable workflow cannot exceed this; it requests
 # less per job.

--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -6,7 +6,7 @@
 version: 1
 
 # Per-stage Claude model. Default: claude-sonnet-5 for every stage.
-# auto_fix and resolve_conflict are Phase 2.
+# resolve_conflict is Phase 2 (M7).
 models:
   implement: claude-sonnet-5
   address_review: claude-sonnet-5
@@ -14,14 +14,15 @@ models:
   resolve_conflict: claude-sonnet-5
 
 # Per-stage --max-turns ceiling.
-# auto_fix and resolve_conflict are Phase 2.
+# resolve_conflict is Phase 2 (M7).
 max_turns:
   implement: 50
   address_review: 30
   auto_fix: 25
   resolve_conflict: 20
 
-# Consecutive CI-fix attempts before giving up (Phase 2). Default: 3.
+# Consecutive CI auto-fix attempts before giving up (0 disables auto-fix:
+# the first red hands straight off to a human). Default: 3.
 attempt_cap: 3
 
 # Max issues worked at once. ready-for-agent is an unbounded queue; the


### PR DESCRIPTION
Adds the smallhours consumer stub (`.github/workflows/agent-loop.yml`) + `.smallhours.yml`, wired to the `CI` workflow. Merge to activate the loop.