### PR TITLE
smallhours M7 validation cleanup

### DIFF
--- a/docs/smallhours-sweep-test.md
+++ b/docs/smallhours-sweep-test.md
@@ -1,2 +1,0 @@
-smallhours M7 sweep test.
-content B: written on the main side, conflicts with the agent branch.


### PR DESCRIPTION
Removes the temporary conflict-exercise file docs/smallhours-sweep-test.md left by the M7 sweep validation.