### PR TITLE
test: survive MediaMTX API restarts in the publish-urls spec

### DIFF
--- a/docs/debt/20260728233517-mediamtx-api-socket-reuse-in-e2e.md
+++ b/docs/debt/20260728233517-mediamtx-api-socket-reuse-in-e2e.md
@@ -1,0 +1,15 @@
+---
+id: 20260728233517
+title: mediamtx-api-socket-reuse-in-e2e
+principal: 2h
+interest: +1 flaky e2e run per CI cycle
+hotspot: tests/e2e
+business_capability: CI/test suite
+payoff_trigger: the next socket-hang-up failure in record-toggle, path-defaults or path-config — promote patchGlobal's poll into a shared tests/e2e helper used by every direct MediaMTX API call
+quadrant: prudent-deliberate
+category: testing
+ai_authored: true
+created: 2026-07-28
+---
+
+MediaMTX restarts its HTTP API server on any config write (core.go closeResources ORs closeAPI with closePathManager and closeRTMPServer), dropping every pooled connection. Playwright reuses pooled sockets, so under fullyParallel any spec's config write can kill a socket another spec is about to reuse, producing "socket hang up". Fixed only in publish-urls.spec.ts, the spec that actually failed CI. record-toggle.spec.ts, path-defaults.spec.ts and path-config.spec.ts make the same direct API calls and carry the same latent flake — they just haven't lost the race yet. Left alone to avoid touching passing tests in a CI-unblocking change.

--- a/tests/e2e/publish-urls.spec.ts
+++ b/tests/e2e/publish-urls.spec.ts
@@ -1,6 +1,28 @@
+import type { APIRequestContext } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
 const API = 'http://localhost:9997/v3'
+
+// MediaMTX restarts its HTTP API server on any config write: in core.go's
+// closeResources, closeAPI is ORed with closePathManager and closeRTMPServer,
+// so both our rtmpAddress patch and the path writes other specs make will tear
+// down the API listener. That drops every open connection, and Playwright pools
+// them — so a request can reuse a socket MediaMTX has already closed and die
+// with "socket hang up" before it even leaves the client. Under fullyParallel
+// that lands on whichever call is unlucky, which is why this only fails in a
+// full run and passes when the spec runs alone. Retrying gets a fresh socket;
+// polling also rides out the moment the listener is down mid-restart. The patch
+// is idempotent, so re-sending it is safe.
+async function patchGlobal(request: APIRequestContext, data: Record<string, unknown>) {
+  await expect.poll(async () => {
+    try {
+      return (await request.patch(`${API}/config/global/patch`, { data })).ok()
+    }
+    catch {
+      return false
+    }
+  }).toBe(true)
+}
 
 // Any ready stream — copying a card's publish URLs reads nothing from the
 // stream itself, only the server's listen addresses, so the choice is free.
@@ -20,7 +42,7 @@ test.describe('Copy publish URLs', () => {
     const before = await (await request.get(`${API}/config/global/get`)).json()
 
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
-    await request.patch(`${API}/config/global/patch`, { data: { rtmpAddress: `:${RTMP_PORT}` } })
+    await patchGlobal(request, { rtmpAddress: `:${RTMP_PORT}` })
     try {
       await page.goto('/')
       const card = page.locator('[data-testid="stream-card"]').filter({ hasText: STREAM })
@@ -39,9 +61,7 @@ test.describe('Copy publish URLs', () => {
       expect(clipboard).not.toContain(':1935/')
     }
     finally {
-      await request.patch(`${API}/config/global/patch`, {
-        data: { rtmpAddress: before.rtmpAddress ?? ':1935' },
-      })
+      await patchGlobal(request, { rtmpAddress: before.rtmpAddress ?? ':1935' })
     }
   })
 })


### PR DESCRIPTION
MediaMTX restarts its HTTP API server on any config write — in core.go's closeResources, closeAPI is ORed with closePathManager and closeRTMPServer — so every open API connection is dropped. Playwright pools connections, so a request can reuse a socket MediaMTX has already closed and fail with "socket hang up" before it leaves the client.

Under fullyParallel the writes other specs make (record-toggle, path-defaults, path-config) drop sockets this spec is about to reuse, which is why it fails in a full run and passes when run alone — and why the failure moved between the initial patch and the restore in the finally block.

Route both global patches through a polling helper: retrying gets a fresh socket, and polling also rides out the moment the listener is down mid-restart. The patch is idempotent, so re-sending it is safe.

Verified against real MediaMTX 1.19.3: reproduced on the full suite before the change (1 flaky), then three consecutive full runs at 61 passed / 0 flaky after.

The other three specs make the same direct API calls and carry the same latent flake; registered in docs/debt/ rather than changing tests that currently pass.