### PR TITLE
fix: make the verify gate work without pnpm on its PATH

### DIFF
--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -89,5 +89,13 @@ sandbox:
 # E2E is deliberately NOT here: it needs a MediaMTX container, Playwright browsers
 # and ffmpeg, none of which exist there, and its web server binds a local port the
 # sandbox forbids. CI owns that. See docs/TESTING.md.
-verify: pnpm verify
+# `npx pnpm@<pinned>` rather than a bare `pnpm`: the gate runs in a fresh
+# non-login `bash -c` on the runner, which does NOT inherit the PATH the agent
+# bootstrapped pnpm onto inside its own session. Issue #300's canary run proved
+# it — the agent installed, tested and edited happily, then the gate came back
+# `exited 127 / bash: line 1: pnpm: command not found` and burned a re-entry
+# trying to fix a repo that was never broken. `npx` ships with node, which the
+# runner always has, and the version is pinned to `packageManager` so the gate
+# and the developer run the same pnpm.
+verify: npx --yes pnpm@11.17.0 run verify
 verify_reentries: 2

--- a/GRILL-QUEUE.md
+++ b/GRILL-QUEUE.md
@@ -1,7 +1,9 @@
 # Grill Queue — ordered (temp working doc)
 
-> Snapshot: **2026-07-28**. Supersedes the roadmap half of `TRIAGE-PLAN.md` (2026-07-17).
-> **No GitHub changes made.** Review this, then we grill top-down.
+> Snapshot: **2026-07-30**, verified against the live board. Supersedes the 2026-07-28
+> revision of this file, which in turn superseded the roadmap half of `TRIAGE-PLAN.md`.
+> **Board mutations made in this revision are listed under "Bookkeeping applied" below.**
+> Nothing was dispatched — no `ready-for-agent` label was applied.
 >
 > Ordering principle (per `CLAUDE.md` § Project goal): **leverage** (does it unblock other
 > work) → **MediaMTX-native fit** (does it consume a config key / endpoint / hook / protocol)
@@ -9,75 +11,80 @@
 
 ---
 
-## What changed since the 07-17 plan
+## What changed since the 07-28 revision
 
-**Shipped and closed** (all `COMPLETED`, all merged to `main`): #197 SECURITY.md · #200 README
-translations · #204 ffmpeg bound · #205 failure domains · #207 hook-restart warning · #208
-revert-to-inherited · #211 WHEP real-transport E2E · #213 publish-URL enable flags · #217 type
-ramp · #219 fixture seeding · #220 breakpoint policy. Plus ADR 0005 (fast test suite),
-conventional-title CI, nightly release train.
+**1. #175 is decomposed — the biggest grill on the old list is done.** On 07-29 it was cut
+into six tickets, each carrying a `Spec: #175` line and a `Blocked by` chain: #291 catalog ·
+#292 detail · #293 live health · #294 config editing · #295 deletion · #296 RTSP wizard. #175
+itself is now a **parent spec** with a "do not label `ready-for-agent`" banner. Old items 7
+and 8 are retired; what replaces them is an *authorization order*, not a grill.
 
-That is **most of Phase 0 and Phase 1's small correctness debt**. Three consequences:
+**2. The loop's wall-clock problem was fixed upstream — F1's first half shipped.**
+`bcanfield/smallhours/.github/workflows/agent-loop.yml@v1` (a moving tag, so this repo already
+has it) now runs `implement` at **`timeout-minutes: 60`** (was 40) with `SMALLHOURS_JOB_CAP_MINUTES: 60`,
+derives the Claude budget *below* the job cap so the run **fails instead of being cancelled**,
+stamps job start before sandbox provisioning so the tail is never charged against it, and keeps
+the `if: failure()` diagnostics upload. Upstream ADR 0007 governs the ordered triple
+(job cap 60 < watchdog 80).
 
-1. **#179 is unblocked** — its stated dependency (#213 enable flags) shipped.
-2. **#201 is now partly stale** — it claims "`apps/web` has no test runner at all." There are
-   now 8 web tests (`apps/web/src/lib/*.test.ts` ×4, `features/**/*.test.tsx` ×4) and ADR 0005
-   is `Implemented`. Real remainder is narrower: `packages/contract` schemas and
-   `apps/api/src/recordings-fs.ts` (`media.serving.test.ts` appears to cover Range).
-3. **Phase 0's gate never landed.** #214 is still open and was *reclaimed by the watchdog on
-   2026-07-28* after sitting `agent-working` 60m with no PR.
+**Still open from that list:**
+- **F1 second half — not landed.** "Implement, open draft PR, report usage" is still one step
+  and `open-pr.sh` still runs *after* `implement.sh`. A hard timeout still leaves no PR.
+- **F4** — `.smallhours.yml` still has no `timeout` key; the 60m cap is fixed upstream.
+- **F5** — `origin/agent/issue-209` is still there (`bad885b`), stale since PR #267 closed.
 
-### ✅ Item 0 — ANSWERED 2026-07-29: it's a wall-clock timeout
+**3. Correction to the 07-28 read on `max_turns`.** That revision said turns were never the
+binding constraint. True for the fat tickets; **false for the thin ones.** #291 — a read-only
+list, the smallest ticket on the board — was handed back at **`2026-07-30T00:56Z` for using
+101 turns against a cap of 100**, not for time. `max_turns.implement` went 100 → 200 in
+`36db1da`, **two minutes later**. So #291 has never run under current settings. Retry before
+concluding anything about ticket size.
 
-Re-running #175 and #177 settled it. Both `implement` jobs were **cancelled at exactly 40
-minutes** (01:55:31 → 02:35:47 and → 02:36:11). The cap lives upstream in
-`bcanfield/smallhours/.github/workflows/agent-loop.yml@v1`; `.smallhours.yml` documents every
-consumer knob and **has no timeout key**, so it isn't tunable from this repo today.
+**4. New, not in the old queue:** #300 (`pnpm check --since` with no ref silently checks the
+working tree and exits 0) — filed 07-31, currently `agent-working`. Leave it alone. It is also
+live evidence for #214: a check that cannot fail is trusted anyway.
 
-Three consequences, in order of how much they cost:
+**5. #175's body cited a nonexistent ADR** for the parent-spec convention (`docs/adr/0006` is
+the pnpm-11 trust exception; nothing in `docs/` describes the pattern). Reference removed. If
+the `Spec:`-line convention is worth keeping, it wants a real ADR — that decision is unmade.
 
-1. **A timeout leaves ZERO artifact.** The implement job is a single step —
-   *"Implement, open draft PR, report usage"* — so the draft PR is opened at the **end**. Cancel
-   it mid-work and there is no branch on `origin`, no PR, and no notes. Confirmed: no
-   `agent/issue-175` or `agent/issue-177` ref exists. 40 minutes of Opus, nothing to resume from.
-2. **You don't even get diagnostics.** The next step, *"Upload give-up diagnostics,"* was
-   **skipped** — a job cancellation skips it, which is precisely when you'd most want it.
-3. **`max_turns` was never the binding constraint.** `implement: 100` (bumped 50 → 75 → 100 over
-   three commits) doesn't bite, because these runs are limited by wall clock, not turns. Those
-   bumps addressed the wrong variable.
+Nothing on the old queue was closed. Every item below is still open.
 
-**Correction to my earlier read:** I guessed harness-over-spec. Half right. The big slate items
-(#175, #177, and by inference #178–#183) are genuinely **too big for one 40m run**. But #214 is
-a different failure — its last run died at **~15m 34s** with `failure`, not a timeout. Don't
-lump it in; grill it on its own evidence.
+---
 
-**Do not re-run any of #175, #177, #178, #180, #181, #182, #185, #186, #187, #188 as written.**
-They're all the same size class and will burn 40 minutes identically.
+## Bookkeeping applied in this revision
 
-For calibration, what *does* fit in 40m is the class that shipped: #204, #207, #208, #213, #217,
-#220 — single-concern debt items touching a handful of files. "Catalog + wizard + detail" is 3–4×
-that budget.
+- `needs-triage` added to the eleven queue items that carried a category label but no state
+  label: #178 #179 #180 #181 #182 #183 #184 #188 #199 #203 #221. All of them are "→ Grill:"
+  entries here, which is exactly what the label means.
+- #175 body: dangling ADR reference removed.
+- **#301 filed** — path rename (create-under-new-name + delete-old). #294 scopes rename out as
+  "its own ticket" and no such ticket existed.
+- **Deliberately left bare:** #292–#296 and #216. They are not awaiting a grill, so
+  `needs-triage` would misdescribe them — they are awaiting *authorization*, and this repo's
+  vocabulary has no label for that. The authorization queue below is that state.
+- **Not filed:** the non-RTSP source kinds #296 defers (rpiCamera, WHEP-redirect, `publisher`,
+  always-available file). Hold until #296 actually ships rather than file four speculative tickets.
 
-#### Recommended fixes, in order
+---
 
-**F1 — Make a timeout leave something behind** (upstream, `bcanfield/smallhours`). Highest
-leverage: independent of ticket size, and it makes every future failure diagnosable.
-- Give the Claude step a **soft budget below the job cap** (e.g. `timeout 32m claude …` under a
-  40m `timeout-minutes`) so it *fails* instead of being *cancelled* — then the existing
-  `if: failure()` diagnostics upload actually runs.
-- **Open the draft PR early**, right after the first commit, instead of at the end. A timeout
-  then leaves a resumable branch rather than nothing.
+## Authorization queue — no grill needed, just a label
 
-**F2 — Split #175** (Tier C, item 7 below). Four 40m-shaped tickets.
+These are specified and blocked only on someone typing `ready-for-agent`. Applying it fires
+smallhours immediately, so promote **one at a time, in this order**:
 
-**F3 — Re-grill #177, don't split it.** Simulcast is a `runOnReady` FFmpeg command generator —
-plausibly a *recipe* inside #178's hooks library rather than a standalone feature. Decide that
-before spending another 40 minutes on it. (Same question already flagged at item 30.)
+| Order | Issue | Why it's ready | Gated on |
+|-------|-------|----------------|----------|
+| 1 | **#291** Paths catalog | Failed only on the old 100-turn cap; cap is now 200 | — |
+| 2 | **#216** Light-mode contrast AA | Clear source, clear task; lost its labels in a loop failure | — |
+| 3 | #292 Per-path detail | Specced out of #175 | #291 |
+| 4 | #296 RTSP add-camera wizard | Specced out of #175 | #291 |
+| 5 | #293 / #294 / #295 | Specced out of #175 | #292 |
+| 6 | #301 Path rename | Not yet grilled — see Tier C | #294, #295 |
 
-**F4 — Add a `timeout` knob to `.smallhours.yml`,** but don't lead with it. A bigger number on an
-unsplit ticket just costs more per failure. Worth having for per-repo tuning after F1/F2.
-
-**F5 — Housekeeping:** `origin/agent/issue-209` is stale, left over from closed PR #267.
+#291 first is also the cheapest experiment on the board: it tells you whether the
+decomposition + the 200-turn cap + the 60m job cap actually close the loop, before any further
+grilling is spent on ticket-sizing.
 
 ---
 
@@ -89,21 +96,25 @@ Rank · issue · why here · **what the grill must resolve** → *tickets it sho
 
 **1. #214 — Implement ADR 0004: coverage floor, `pnpm verify`, FEATURES.md gate**
 Highest leverage on the board: every agent-executed issue below is safer once it lands, and it
-has now failed the loop twice. ADR is `Accepted`; only the mechanisms are missing.
+has now failed the loop twice. ADR is `Accepted`; only the mechanisms are missing. #300 is a
+live instance of the exact failure mode ADR 0004 exists to prevent.
 → Grill: is this one ticket or three? The coverage floor (pick a baseline number), `pnpm verify`
 (a script), and the FEATURES.md CI gate are independent and each is ~30 min. Splitting them is
-probably why it keeps dying. Also: does ADR 0005's restructure change the baseline the floor
-should be set from? *Produces: 3 tickets.*
+probably why it keeps dying — and the #175 split is the precedent that it works. Also: does ADR
+0005's restructure change the baseline the floor should be set from? *Produces: 3 tickets.*
 
 **2. #201 — Remaining test layers** — **re-scope, don't implement as written**
-Its premise is stale (see above). Grill: what's actually uncovered now, and does ADR 0005
-already close part of it? *Produces: 1–2 narrow tickets (`packages/contract` schemas,
-`recordings-fs.ts`) and a body rewrite. Possibly closes as mostly-done.*
+Its premise is stale: it claims "`apps/web` has no test runner at all," but there are now 8 web
+tests (`apps/web/src/lib/*.test.ts` ×4, `features/**/*.test.tsx` ×4) and ADR 0005 is
+`Implemented`. Real remainder is narrower: `packages/contract` schemas and
+`apps/api/src/recordings-fs.ts` (`media.serving.test.ts` appears to cover Range).
+→ Grill: what's actually uncovered now, and does ADR 0005 already close part of it?
+*Produces: 1–2 narrow tickets and a body rewrite. Possibly closes as mostly-done.*
 
 **3. #212 — `webrtcAdditionalHosts` hardcodes 127.0.0.1**
-This is a silent correctness bug on the **shipped flagship path**: WHEP is the default player
-(#174), and any non-localhost deployment loses it, falls back to HLS, and shows the operator
-working video with no signal. Currently `needs-triage` behind a maintainer pick.
+A silent correctness bug on the **shipped flagship path**: WHEP is the default player (#174), and
+any non-localhost deployment loses it, falls back to HLS, and shows the operator working video
+with no signal.
 → Grill: the issue frames it as either/or — derive the host from `REMOTE_MEDIAMTX_URL` at boot,
 *or* surface "WebRTC unreachable" in the UI. **Push on why not both**: derive it (fixes the
 common case) *and* detect ICE failure in the player (honest when derivation is wrong). The
@@ -117,7 +128,8 @@ Gates #203, #199, #226, and version-pins #184's compatibility matrix. Failed the
 diff size? Should it be split by scope (global / pathDefaults / paths)? *Produces: 1–3 tickets.*
 
 **5. #203 — Widen path scopes beyond `record*`/`runOn*` (~80 missing `pathDefaults` keys)**
-Gates #226 (resilience editors), #178 (hooks UI), #182 (recording mgmt). After #202.
+Gates #226 (resilience editors), #178 (hooks UI), #182 (recording mgmt), and widens what #294
+can edit. After #202.
 → Grill: all 80 at once, or the subset that unblocks a named downstream feature? Does the form
 need new field *types* (arrays, nested) or is it more of the same? *Produces: 2–4 tickets.*
 
@@ -125,28 +137,24 @@ need new field *types* (arrays, nested) or is it more of the same? *Produces: 2�
 → Grill: is this verifiable mechanically against the upstream schema descriptions, or does it
 need a human read? Determines whether it's agent work at all.
 
-### Tier C — The per-path spine (biggest decomposition job on the board)
+### Tier C — The per-path spine (decomposed; residual grills only)
 
-**7. #175 — Per-path management: catalog, detail + live health, guided Add-camera**
-Three features in one ticket, partially shipped (the per-path editor exists — §3.4, ADR 0002),
-and it died in the loop. Most of the slate hangs off it. **This is the single most valuable
-grill on the list.**
-→ Grill: split into *paths catalog* (list/create/delete via `v3/config/paths/*`) · *add-camera
-wizard* (source-kind branching: RTSP / rpiCamera / redirect / publisher / always-available) ·
-*per-path detail + health* (`pathsGet` / `tracks2`) · *delete with active-publisher warning*.
-Which one ships first? Is the wizard worth it before #203 widens the key set?
-*Produces: 3–4 tickets.*
+**7. #301 — Path rename** — the one piece of the spine that is *not* grilled.
+Filed from #294's out-of-scope note. It is create-then-delete with no atomicity from MediaMTX.
+→ Grill: what happens on a partial failure, and is rename worth shipping at all versus telling
+the operator to recreate? Regex-backed paths make it worse (§ ADR 0002). *Produces: 1 ticket or a close.*
 
-**8. #210 — Nav entry for the three config scopes** — **grill together with #175, not separately**
-It's `needs-triage` as "undesigned surface," but the paths catalog from #175 *is* the missing
-nav destination. Deciding #175's catalog decides this.
-→ Grill: sub-nav under the MediaMTX Config tab vs. a scope switcher on the config pages —
-and does #175's catalog replace the question entirely?
+**8. #210 — Nav entry for the three config scopes** — now a one-sentence decision, not a session.
+#291's catalog route *is* the missing nav destination.
+→ Grill: does #291's route close this outright, or is a scope switcher still wanted for
+global / `pathDefaults` / per-path? Answer it when #291 lands, not before.
 
 **9. #209 — Path config dead-ends for idle wildcard-backed streams**
 `bug` + `ready-for-human` after PR #267 was closed unmerged *and* a later run failed. Same
-surface as #175, well-specified (render an honest empty state, don't reimplement regex matching).
-→ Grill: short — why did #267 get closed? If the spec is right, this just needs a re-run.
+surface as the #29x chain, well-specified (render an honest empty state, don't reimplement
+regex matching).
+→ Grill: short — why did #267 get closed? If the spec is right this just needs a re-run, and it
+may be subsumed by #292's inherited-vs-overridden rendering. *Also: delete the stale branch.*
 
 ### Tier D — Cheap native wins the loop can actually finish
 
@@ -156,45 +164,40 @@ generated client, no dependencies, body already grilled (native/UX/edges + scope
 → Grill: mostly a spec-out pass — which endpoints in v1, poll interval floor, table columns,
 kick confirm copy. *Produces: 1 ticket, or 2 (table / kick).*
 
-**11. #179 — Publish-URL helper with OBS/FFmpeg/GStreamer recipes** — **now unblocked** (#213 shipped)
+**11. #179 — Publish-URL helper with OBS/FFmpeg/GStreamer recipes** — unblocked (#213 shipped)
 Partially shipped (copy-URLs on the card, empty state). Remaining: per-path side panel, WHIP URL,
 publisher snippets, hide tabs when a protocol is disabled.
 → Grill: **merge #227 and #228 into this?** All three derive URLs from the same
 `apps/web/src/lib/publish.ts` builder. One "URL surface" ticket beats three.
 
 **12. #227 — External-player links + per-protocol client cheat sheet** — merge candidate → #11.
-The read-side twin of the shipped publish builder.
 
-**13. #228 — QR codes for publish/read URLs** — merge candidate → #11. Client-side rendering of
-URLs #11 already computes.
+**13. #228 — QR codes for publish/read URLs** — merge candidate → #11.
 
 **14. #187 — Setup wizard + doctor/preflight diagnostics**
-Promoted above the rest of the slate: the doctor page is "a stack of small checks" (API reach,
-recordings dir writable, ffmpeg present, version supported, clock drift, port binds) — unusually
-high agent-implementability for a slate item, and it's where #212's WebRTC-unreachable check
-belongs.
-→ Grill: **split the doctor from the wizard.** Doctor is agent-ready today; the wizard is
-design work. Which checks in v1? *Produces: 2 tickets.*
+The doctor page is "a stack of small checks" (API reach, recordings dir writable, ffmpeg present,
+version supported, clock drift, port binds) — unusually high agent-implementability for a slate
+item, and it's where #212's WebRTC-unreachable check belongs.
+→ Grill: **split the doctor from the wizard.** Doctor is agent-ready today; the wizard is design
+work. Which checks in v1? *Produces: 2 tickets.*
 
 **15. #184 — Codec ↔ protocol compatibility matrix**
-Native (reads `tracks2`), well-grilled body, no hard dependency — but the matrix rules are
+Native (reads `tracks2`), well-grilled body, no hard dependency — but the rules are
 version-pinned, so land after #202.
 → Grill: where the rules table lives and how it's kept honest across MediaMTX versions.
 
 **16. #221 — Recording metadata: ffprobe duration/codec, resolution chip, bitrate rate**
-The body already identifies **three independent pieces** in landing order — it's pre-decomposed,
-it just needs splitting into three tickets. Piece 2 (resolution chip) is a contract-widening job
-with no new MediaMTX call — nearly free.
-→ Grill: minimal. *Produces: 3 tickets.*
+The body already identifies **three independent pieces** in landing order — pre-decomposed, it
+just needs splitting. Piece 2 (resolution chip) is a contract-widening job with no new MediaMTX
+call — nearly free. → Grill: minimal. *Produces: 3 tickets.*
 
 ### Tier E — Recording & playback depth (big, sequential)
 
 **17. #180 — NVR-style recording timeline (playback server `/list` + `/get`)**
 The anchor of the recording story, and the hardest unshipped thing on the board.
 → Grill: the **precondition** first — it requires `recordFormat: fmp4` *and* the playback server
-enabled. What happens on an mpegts path? Do we detect and warn (backlog item
-"format-mismatch warning"), or block? Then decompose: read-only day view → zoom/scrub →
-cross-segment stitched playback. *Produces: 3–4 tickets.*
+enabled. What happens on an mpegts path? Detect and warn, or block? Then decompose: read-only day
+view → zoom/scrub → cross-segment stitched playback. *Produces: 3–4 tickets.*
 
 **18. #181 — Server-side clip export (in/out → MP4)** — builds on #17's `/get` plumbing.
 
@@ -204,12 +207,12 @@ toggle + `record*` keys). Needs #203 for the retention keys.
 
 ### Tier F — Ungrilled backlog (#222–#230), ordered by native fit
 
-These are one-paragraph stubs with an "Idea + Native fit" section and an explicit
-*"not yet grilled"* footer. Each needs a real three-lens grill before it can become tickets.
+One-paragraph stubs with an "Idea + Native fit" section and an explicit *"not yet grilled"*
+footer. Each needs a real three-lens grill before it can become tickets.
 
 **20. #226 — Path resilience: `alwaysAvailable` + `sourceOnDemand` controls** — highest native
-fit of the nine (pure per-path config keys), but **blocked on #203** widening the key set.
-Grill it right after #203 so it rides the same form work.
+fit of the nine (pure per-path config keys), but **blocked on #203**. Grill it right after #203
+so it rides the same form work — and after #294, so it rides the same editor.
 
 **21. #225 — Auth management: internal users CRUD + hardening checklist**
 MediaMTX's main security surface, currently hand-written YAML. High value, high blast radius.
@@ -225,17 +228,17 @@ separate container; `logDestinations`/`logFile` has to be configured and the fil
 precondition may sink v1 — establish it before speccing anything.
 
 **24. #222 — Config snapshot history + diff preview + rollback** — storage is ours, not
-MediaMTX's, so it's a step down in native fit, but it makes the *existing* config editor safe.
+MediaMTX's, so a step down in native fit, but it makes the *existing* config editor safe — and
+more so once #294 lets the agent-facing surface write paths too.
 → Grill: retention of snapshots, where they're stored, and whether the diff-preview-before-save
 half ships independently (it's the cheaper, more useful half).
 
 **25. #229 — Config export/import (yml round-trip + dry-run diff)** — **merge candidate → #24.**
-Same diff machinery, same patch procedures.
 
 **26. #230 — Notification targets + webhook health alerts** — lowest native fit of the nine
-(it's our own alerting infra riding `runOn*`), but the body claims it's "the loudest ask from the
-surveillance cohort after recording management." Per `CLAUDE.md`, it must **lead with why it
-earns priority** despite being app-level. → Grill that claim first — is the demand evidence real?
+(our own alerting infra riding `runOn*`), but the body claims it's "the loudest ask from the
+surveillance cohort after recording management." Per `CLAUDE.md` it must **lead with why it earns
+priority** despite being app-level. → Grill that claim first — is the demand evidence real?
 
 ### Tier G — Remaining slate (reach)
 
@@ -252,7 +255,8 @@ editor already exists (§3.4). → Grill: is this just "add the snippet library 
 editor"? That would be small.
 
 **30. #177 — Multi-destination simulcast manager (`runOnReady` FFmpeg fan-out)** — powerful, but
-it's a hook-command generator; grill whether it's a #178 recipe rather than its own feature.
+it's a hook-command generator; grill whether it's a #178 recipe rather than its own feature
+before spending another run on it.
 
 **31. #186 — go2rtc / Frigate config import** — lowest confidence (their formats aren't stable
 contracts). → Grill: is a best-effort importer worth the maintenance, or is a documented
@@ -260,29 +264,35 @@ migration guide the honest answer?
 
 ### Tier H — Cheap decision grills (~10 min each, run any time)
 
-**32. #216 — Light-mode contrast fails AA** — **not a grill; a mislabel.** Clear source, clear
-task (extend the axe suite to both themes, fix the light tiers). It lost its state labels in the
-loop failure and is now unlabeled. Just relabel `ready-for-agent`.
-
-**33. #206 — Record toggle has no pending state** — needs a design call on the pending
+**32. #206 — Record toggle has no pending state** — needs a design call on the pending
 affordance. Grill: is a spinner really "undesigned surface," or is disabled-while-pending the
 obvious boring answer? (Suspect the latter — this may be agent-ready.)
 
-**34. #189 — Snapshot capture from live view** — server-side snapshot already shipped (§1.2.4).
+**33. #189 — Snapshot capture from live view** — server-side snapshot already shipped (§1.2.4).
 Grill: is the remaining canvas/clipboard/gallery scope still wanted, or does it close?
 
-**35. #176 — Latency chip** — blocked on a metric definition; the shipped player deliberately
+**34. #176 — Latency chip** — blocked on a metric definition; the shipped player deliberately
 dropped the number for lack of an honest cross-transport metric. Grill: accept two
 transport-specific numbers with different labels, or close it?
 
-**36. #215 — Env var semantics residuals** — changes a documented deployment interface; needs
+**35. #215 — Env var semantics residuals** — changes a documented deployment interface; needs
 sign-off, then it's a ~30 min sweep.
 
-**37. #218 — Global density preference** — was an explicit product choice. Grill: has the
+**36. #218 — Global density preference** — was an explicit product choice. Grill: has the
 cramped feel actually been confirmed as a problem? If no signal, close it.
 
-**38. #100 — RTL languages** — a bare shadcn link, no spec. Grill: is RTL in scope at all given
+**37. #100 — RTL languages** — a bare shadcn link, no spec. Grill: is RTL in scope at all given
 the current locale set (en/es/zh/it)? Cheapest close on the board if not.
+
+### Tier I — Loop infrastructure (upstream, not this repo's issue board)
+
+**38. F1 second half — open the draft PR before the work, not after.** The 60m cap now fails
+gracefully, but a timeout still leaves no branch and no PR to resume from.
+
+**39. F4 — a `timeout` knob in `.smallhours.yml`.** Lower priority now that the cap is 60 and the
+budget is derived; worth it for per-repo tuning.
+
+**40. F5 — delete `origin/agent/issue-209`** (`bad885b`). One command. Do it with #9.
 
 ---
 
@@ -293,17 +303,22 @@ the current locale set (en/es/zh/it)? Cheapest close on the board if not.
 | #4 | Renovate-managed — never label or touch |
 | #190 | Epic; sequencing stays with the maintainer (this doc is its sequencing) |
 | #198 | Native-speaker translation review — inherently human, not grillable |
+| #175 | Parent spec, not a unit of work — never label `ready-for-agent` |
+| #300 | In flight (`agent-working`) — do not touch |
 
 ---
 
-## Proposed first session
+## Proposed next session
 
-Items **0 → 3**: diagnose the loop failure, then grill #214 (split into three), re-scope #201,
-and settle #212. That restores the safety rails and fixes a live bug on the flagship path
-before any new feature work enters the loop.
+**Grill #214 first** (item 1). Unchanged from the last revision, and now better motivated: it has
+failed the loop twice, its grill question is a decomposition — the same shape that just worked on
+#175 — and #300 is a live specimen of the silent-success failure ADR 0004 exists to stop.
 
-Then items **7–8** (#175 + #210 together) — the single decomposition that unblocks the most
-downstream slate work.
+Then items **2 and 3** (#201 re-scope, #212 both-halves), which restore the safety rails and fix a
+live bug on the flagship path before new feature work enters the loop.
 
-**Reminder:** applying `ready-for-agent` fires smallhours immediately. Re-label in small batches
-in this order, not all at once.
+Separately from grilling, the authorization queue above is ready whenever you want to dispatch —
+**#291 is the highest-information single label on the board**, since it tests the decomposition
+and both raised caps at once.
+
+**Reminder:** applying `ready-for-agent` fires smallhours immediately. Promote one at a time.


### PR DESCRIPTION
The canary run on #300 proved the loop end to end and found one defect. The agent installed dependencies, ran the suite, wrote tests and edited the lockfile happily — then the gate came back:

    $ pnpm verify
    exited 127
    bash: line 1: pnpm: command not found

The gate runs in a fresh non-login `bash -c` on the runner. It does not inherit the PATH the agent bootstrapped pnpm onto inside its own session, so a bare `pnpm` was never going to resolve there. Nothing was wrong with the repo, which is the expensive part: the re-entry then spent 31 turns and $2.22 trying to fix code that was already correct.

`npx` ships with node, which the runner always has, and the version is pinned to `packageManager` so the gate and a developer run the same pnpm. Verified by stripping pnpm from PATH locally and reproducing 127 against the old command, then watching the new one pass.

Everything else in the run behaved as designed: the sandbox allowWrite paths were right (pnpm-lock.yaml changed, so the store write succeeded), re-entry fired with --continue, and a still-red gate pushed anyway and put the command, exit status and output on the PR rather than shipping a silent red.