### PR TITLE
chore: derive conventional PR titles from issue labels

### DIFF
--- a/.smallhours.yml
+++ b/.smallhours.yml
@@ -99,3 +99,27 @@ sandbox:
 # and the developer run the same pnpm.
 verify: npx --yes pnpm@11.17.0 run verify
 verify_reentries: 2
+
+# Prefix agent PR titles with a conventional-commit type derived from the
+# issue's labels. `main` is squash-merged, so the PR title IS the subject
+# semantic-release parses — an unprefixed one fails the repo's own
+# `Conventional commit format` check and, before smallhours#30, cost a whole
+# auto-fix attempt to correct on a PR whose code was already green.
+#
+# Presence is the opt-in; absent, titles pass through verbatim.
+#
+# `tech-debt: fix` deliberately, not `refactor`. Debt issues here are routinely
+# real user-visible fixes — #206 (record toggle showed a stale state through the
+# whole write) is one, and its body says "Ships as `fix:`". `refactor` cuts no
+# release, and CLAUDE.md is explicit that silently dropping a change out of the
+# next release is the failure worth avoiding. An extra patch on a nightly
+# release train is cheap by comparison.
+#
+# This buys a title that PASSES, not a title that is good: the map cannot know
+# that #206 is better described as "show pending state on record toggle" than by
+# its own problem-statement title. Retitling a PR by hand stays worthwhile.
+conventional_title_types:
+  bug: fix
+  tech-debt: fix
+  enhancement: feat
+  documentation: docs

--- a/GRILL-QUEUE.md
+++ b/GRILL-QUEUE.md
@@ -284,7 +284,7 @@ migration guide the honest answer?
 
 ### Tier H — Cheap decision grills (~10 min each, run any time)
 
-**32. #206 — Record toggle has no pending state** — needs a design call on the pending
+**32. #206 (GRILLED ALREADY) — Record toggle has no pending state** — needs a design call on the pending
 affordance. Grill: is a spinner really "undesigned surface," or is disabled-while-pending the
 obvious boring answer? (Suspect the latter — this may be agent-ready.)
 

--- a/docs/debt/20260730215531-verify-gate-pnpm-pin-duplicated.md
+++ b/docs/debt/20260730215531-verify-gate-pnpm-pin-duplicated.md
@@ -1,0 +1,19 @@
+---
+id: 20260730215531
+title: verify-gate-pnpm-pin-duplicated
+principal: 15m
+interest: +1 wasted agent run per drift — the gate runs the wrong pnpm and its failure looks like a code defect
+hotspot: .smallhours.yml, package.json
+business_capability: unknown
+payoff_trigger: bcanfield/smallhours#29 lands — then drop the npx wrapper and return to a bare `pnpm verify`
+quadrant: prudent-deliberate
+category: infrastructure
+ai_authored: true
+created: 2026-07-30
+---
+
+`.smallhours.yml`'s verify command hardcodes `npx --yes pnpm@11.17.0`, duplicating the version already pinned in `package.json`'s `packageManager` field. Renovate bumps `packageManager` and will not touch `.smallhours.yml`, so after the next pnpm major the agent's verify gate silently runs the old pnpm against a lockfile the new one resolved — and the resulting failure reads as a code defect rather than a version skew.
+
+It exists as a workaround for a toolkit bug, not a repo one: the smallhours verify gate runs the consumer command in a non-login `bash -c` that cannot see the PATH the agent bootstrapped pnpm onto, so a bare `pnpm verify` returned exit 127 (`command not found`) on the first live run (mediamtx-connect#300). That run then spent 31 turns and $2.22 re-entering the agent to fix code that was never broken.
+
+Filed upstream as bcanfield/smallhours#29 with four candidate fixes. Once one lands, this duplication should disappear rather than be kept in sync.


### PR DESCRIPTION
smallhours v0.5.10 adds an opt-in `conventional_title_types` map; presence is the opt-in, so without this the toolkit still titles agent PRs from the issue title verbatim.

That verbatim title is what failed #307 and #308. `main` is squash-merged, so the PR title is the subject semantic-release parses, and "Record toggle has no pending/optimistic state" fails the repo's own commit-format check. Before smallhours#30 that cost a full auto-fix attempt on a PR whose code was already green; with #30 fixed it no longer strands the PR, but it still spends an attempt on something this map buys for free.

`tech-debt: fix`, not `refactor`. Debt issues here are routinely real user-visible fixes — #206 is one, and its body says "Ships as `fix:`" — and CLAUDE.md is explicit that silently dropping a change out of the next release is the failure worth avoiding. An extra patch on a nightly release train is the cheaper error.

Verified against the toolkit's own config_pr_title: tech-debt and enhancement titles get prefixed, an already-prefixed title is left alone.